### PR TITLE
카카오 로그인 리팩토링 및 이메일 관련 버그 수정

### DIFF
--- a/src/main/java/com/innovation/stockstock/dto/KakaoMemberInfoDto.java
+++ b/src/main/java/com/innovation/stockstock/dto/KakaoMemberInfoDto.java
@@ -3,10 +3,9 @@ package com.innovation.stockstock.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
+@AllArgsConstructor
 public class KakaoMemberInfoDto {
-    private Long id;
     private String nickname;
     private String email;
 }

--- a/src/main/java/com/innovation/stockstock/entity/Member.java
+++ b/src/main/java/com/innovation/stockstock/entity/Member.java
@@ -2,8 +2,6 @@ package com.innovation.stockstock.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import javax.persistence.*;
 import javax.persistence.*;
 
 @Entity
@@ -16,17 +14,9 @@ public class Member {
     private Long id;
     private String email;
     private String nickname;
-    private Long kakaoId;
 
     public Member(String email, String nickname) {
         this.email = email;
         this.nickname = nickname;
-    }
-
-    public Member(String email, String nickname, Long kakaoId) {
-        this.email = email;
-        this.nickname = nickname;
-        this.kakaoId = kakaoId;
-
     }
 }

--- a/src/main/java/com/innovation/stockstock/repository/MemberRepository.java
+++ b/src/main/java/com/innovation/stockstock/repository/MemberRepository.java
@@ -7,5 +7,4 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
-    Optional<Member> findByKakaoId(Long kakaoId);
 }


### PR DESCRIPTION
- 프론트에서는 명세서 주소대로 요청가능하고, 그 이후 로직은 내부적으로 처리
- 이메일 선택사항이라 동의하지 않았을 때 예외처리
- 카카오 id 관련한 제거
- #2